### PR TITLE
Fix docker execution step in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Ubuntuの場合はホストマシンにMediaPipeをインストールせず、Do
 docker-compose build
 ```
 
+GUIアプリケーションの起動（X11 Forwarding）を許可します。
+
+```
+xhost +local:root
+```
+
 最後にDockerコンテナを起動します。
 
 ```


### PR DESCRIPTION
https://github.com/Kazuhito00/Tokyo2020-Pictogram-using-MediaPipe/pull/1 の修正です。